### PR TITLE
feat(mj-column): handle inner attributes

### DIFF
--- a/resources/compare/success/mj-column-inner-background-color.html
+++ b/resources/compare/success/mj-column-inner-background-color.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+  <head>
+    <title>
+    </title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a {
+        padding: 0;
+      }
+
+      body {
+        margin: 0;
+        padding: 0;
+        -webkit-text-size-adjust: 100%;
+        -ms-text-size-adjust: 100%;
+      }
+
+      table,
+      td {
+        border-collapse: collapse;
+        mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+      }
+
+      img {
+        border: 0;
+        height: auto;
+        line-height: 100%;
+        outline: none;
+        text-decoration: none;
+        -ms-interpolation-mode: bicubic;
+      }
+
+      p {
+        display: block;
+        margin: 13px 0;
+      }
+    </style>
+    <!--[if mso]>
+<noscript>
+<xml>
+<o:OfficeDocumentSettings>
+<o:AllowPNG/>
+<o:PixelsPerInch>96</o:PixelsPerInch>
+</o:OfficeDocumentSettings>
+</xml>
+</noscript>
+<![endif]-->
+    <!--[if lte mso 11]>
+<style type="text/css">
+.mj-outlook-group-fix { width:100% !important; }
+</style>
+<![endif]-->
+    <!--[if !mso]><!-->
+    <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+    <style type="text/css">
+      @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+    </style>
+    <!--<![endif]-->
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 {
+          width: 100% !important;
+          max-width: 100%;
+        }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
+      }
+    </style>
+  </head>
+
+  <body style="word-spacing:normal;">
+    <div>
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+      <div style="margin:0px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+                <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                    <tbody>
+                      <tr>
+                        <td style="background-color:#E7E7E7;border-radius:6px;vertical-align:top;padding:1px;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="background-color:#ffffff;border-radius:6px;" width="100%">
+                            <tbody>
+                              <tr>
+                                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">Hello World!</div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    </div>
+  </body>
+
+</html>

--- a/resources/compare/success/mj-column-inner-background-color.mjml
+++ b/resources/compare/success/mj-column-inner-background-color.mjml
@@ -1,0 +1,11 @@
+<mjml>
+  <mj-body>
+    <mj-section>
+      <mj-column padding="1px" background-color="#E7E7E7" inner-background-color="#ffffff" border-radius="6px" inner-border-radius="6px">
+        <mj-text>
+          Hello World!
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/src/mj_column/render.rs
+++ b/src/mj_column/render.rs
@@ -120,6 +120,44 @@ impl<'e, 'h> MJColumnRender<'e, 'h> {
     }
 
     fn set_style_table_gutter(&self, tag: Tag) -> Tag {
+        tag.maybe_add_style(
+            "background-color",
+            self.attribute("inner-background-color")
+                .or_else(|| self.attribute("background-color")),
+        )
+        .maybe_add_style(
+            "border",
+            self.attribute("inner-border")
+                .or_else(|| self.attribute("border")),
+        )
+        .maybe_add_style(
+            "border-bottom",
+            self.attribute("inner-border-bottom")
+                .or_else(|| self.attribute("border-bottom")),
+        )
+        .maybe_add_style(
+            "border-left",
+            self.attribute("inner-border-left")
+                .or_else(|| self.attribute("border-left")),
+        )
+        .maybe_add_style(
+            "border-radius",
+            self.attribute("inner-border-radius")
+                .or_else(|| self.attribute("border-radius")),
+        )
+        .maybe_add_style(
+            "border-right",
+            self.attribute("inner-border-right")
+                .or_else(|| self.attribute("border-right")),
+        )
+        .maybe_add_style(
+            "border-top",
+            self.attribute("inner-border-top")
+                .or_else(|| self.attribute("border-top")),
+        )
+    }
+
+    fn set_style_table_simple(&self, tag: Tag) -> Tag {
         tag.maybe_add_style("background-color", self.attribute("background-color"))
             .maybe_add_style("border", self.attribute("border"))
             .maybe_add_style("border-bottom", self.attribute("border-bottom"))
@@ -127,10 +165,6 @@ impl<'e, 'h> MJColumnRender<'e, 'h> {
             .maybe_add_style("border-radius", self.attribute("border-radius"))
             .maybe_add_style("border-right", self.attribute("border-right"))
             .maybe_add_style("border-top", self.attribute("border-top"))
-    }
-
-    fn set_style_table_simple(&self, tag: Tag) -> Tag {
-        self.set_style_table_gutter(tag)
             .maybe_add_style("vertical-align", self.attribute("vertical-align"))
     }
 
@@ -340,6 +374,18 @@ mod tests {
         let opts = Options::default();
         let template = include_str!("../../resources/compare/success/mj-column-class.mjml");
         let expected = include_str!("../../resources/compare/success/mj-column-class.html");
+        let root = MJML::parse(template).unwrap();
+        let result = root.render(&opts).unwrap();
+        compare(expected, result.as_str());
+    }
+
+    #[test]
+    fn inner_background_color() {
+        let opts = Options::default();
+        let template =
+            include_str!("../../resources/compare/success/mj-column-inner-background-color.mjml");
+        let expected =
+            include_str!("../../resources/compare/success/mj-column-inner-background-color.html");
         let root = MJML::parse(template).unwrap();
         let result = root.render(&opts).unwrap();
         compare(expected, result.as_str());


### PR DESCRIPTION
This PR fixes https://github.com/jdrouet/mrml/issues/300.
The `inner-*` attributes on `mj-column` were not yet handled. Now it's ok.

Signed-off-by: Jérémie Drouet <jeremie.drouet@gmail.com>