### PR TITLE
Add link to MJML markup documentation to README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@
 
 ## Introduction
 
-This project is a reimplementation of the nice MJML markup language in Rust.
+This project is a reimplementation of the nice [MJML markup language](https://documentation.mjml.io/) in Rust.
 
 ## How to use it in my code
 


### PR DESCRIPTION
It's a tiny change, but I believe it will help someone find markup documentation without going to a search engines.